### PR TITLE
Fix workflows: Use proper secrets architecture

### DIFF
--- a/.github/workflows/ai-code-analysis.yml
+++ b/.github/workflows/ai-code-analysis.yml
@@ -4,15 +4,6 @@ on:
   # Make this a reusable workflow
   workflow_call:
     inputs:
-      github_token:
-        description: 'GitHub token for API access'
-        required: false
-        type: string
-        default: ''
-      personal_access_token:
-        description: 'Personal access token for user verification'
-        required: true
-        type: string
       target_ref:
         description: 'Target ref to analyze (default: PR head)'
         required: false
@@ -23,6 +14,13 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      GITHUB_TOKEN:
+        description: 'GitHub token for API access'
+        required: false
+      PERSONAL_ACCESS_TOKEN:
+        description: 'Personal access token for user verification'
+        required: true
   
   # Still support direct usage on pull requests
   pull_request_target:
@@ -41,8 +39,8 @@ jobs:
       PR_USER_LOGIN: ${{ github.event.pull_request.user.login }}
       PR_HEAD_SHA: ${{ inputs.target_ref || github.event.pull_request.head.sha }}
       PR_BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
-      GITHUB_TOKEN_INPUT: ${{ inputs.github_token || github.token }}
-      PAT_TOKEN: ${{ inputs.personal_access_token }}
+      GITHUB_TOKEN_INPUT: ${{ secrets.GITHUB_TOKEN || github.token }}
+      PAT_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
     
     steps:
       - name: Verify user

--- a/.github/workflows/ai-dashboard.yml
+++ b/.github/workflows/ai-dashboard.yml
@@ -4,16 +4,6 @@ on:
   # Make this a reusable workflow
   workflow_call:
     inputs:
-      github_token:
-        description: 'GitHub token for repository operations'
-        required: false
-        type: string
-        default: ''
-      shiftai_token:
-        description: 'ShiftAI token for auto-merge operations'
-        required: false
-        type: string
-        default: ''
       target_branch:
         description: 'Target branch for the dashboard (default: master)'
         required: false
@@ -29,6 +19,13 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      GITHUB_TOKEN:
+        description: 'GitHub token for repository operations'
+        required: false
+      SHIFTAI_TOKEN:
+        description: 'ShiftAI token for auto-merge operations'
+        required: false
   
   # Still support direct triggers
   pull_request_target:
@@ -64,8 +61,8 @@ jobs:
       PR_NUMBER: ${{ inputs.pr_number || github.event.number || 'manual' }}
       REPO_NAME: ${{ inputs.repository_name || github.repository }}
       TARGET_BRANCH: ${{ inputs.target_branch || github.event.repository.default_branch || 'master' }}
-      GITHUB_TOKEN_INPUT: ${{ inputs.github_token || github.token }}
-      SHIFTAI_TOKEN_INPUT: ${{ inputs.shiftai_token }}
+      GITHUB_TOKEN_INPUT: ${{ secrets.GITHUB_TOKEN || github.token }}
+      SHIFTAI_TOKEN_INPUT: ${{ secrets.SHIFTAI_TOKEN }}
     
     steps:
       - name: Check if this is a dashboard update PR (prevent loops)


### PR DESCRIPTION
- Move tokens from inputs to secrets section (GitHub requirement)
- PERSONAL_ACCESS_TOKEN now properly handled as secret
- GITHUB_TOKEN and SHIFTAI_TOKEN use secrets context
- Simplified inputs to only essential customizations
- Follows GitHub's security best practices