### PR TITLE
Prince/Add shiftai workflows

### DIFF
--- a/.github/workflows/ai-code-analysis.yml
+++ b/.github/workflows/ai-code-analysis.yml
@@ -15,7 +15,7 @@ on:
         type: string
         default: ''
     secrets:
-      GITHUB_TOKEN:
+      GH_TOKEN:
         description: 'GitHub token for API access'
         required: false
       PERSONAL_ACCESS_TOKEN:
@@ -39,7 +39,7 @@ jobs:
       PR_USER_LOGIN: ${{ github.event.pull_request.user.login }}
       PR_HEAD_SHA: ${{ inputs.target_ref || github.event.pull_request.head.sha }}
       PR_BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
-      GITHUB_TOKEN_INPUT: ${{ secrets.GITHUB_TOKEN || github.token }}
+      GITHUB_TOKEN_INPUT: ${{ secrets.GH_TOKEN || github.token }}
       PAT_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
     
     steps:

--- a/.github/workflows/ai-dashboard.yml
+++ b/.github/workflows/ai-dashboard.yml
@@ -20,7 +20,7 @@ on:
         type: string
         default: ''
     secrets:
-      GITHUB_TOKEN:
+      GH_TOKEN:
         description: 'GitHub token for repository operations'
         required: false
       SHIFTAI_TOKEN:
@@ -61,7 +61,7 @@ jobs:
       PR_NUMBER: ${{ inputs.pr_number || github.event.number || 'manual' }}
       REPO_NAME: ${{ inputs.repository_name || github.repository }}
       TARGET_BRANCH: ${{ inputs.target_branch || github.event.repository.default_branch || 'master' }}
-      GITHUB_TOKEN_INPUT: ${{ secrets.GITHUB_TOKEN || github.token }}
+      GITHUB_TOKEN_INPUT: ${{ secrets.GH_TOKEN || github.token }}
       SHIFTAI_TOKEN_INPUT: ${{ secrets.SHIFTAI_TOKEN }}
     
     steps:


### PR DESCRIPTION
- Rename GITHUB_TOKEN to GH_TOKEN (GitHub reserves GITHUB_TOKEN)
- Fixes error: secret name GITHUB_TOKEN within workflow_call collides with system reserved name
- Maintains same functionality with non-reserved secret name