### PR TITLE
Final fix: Use github.token directly for inherited secrets

### DIFF
--- a/.github/workflows/ai-code-analysis.yml
+++ b/.github/workflows/ai-code-analysis.yml
@@ -36,7 +36,7 @@ jobs:
       PR_USER_LOGIN: ${{ github.event.pull_request.user.login }}
       PR_HEAD_SHA: ${{ inputs.target_ref || github.event.pull_request.head.sha }}
       PR_BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
-      GITHUB_TOKEN_INPUT: ${{ secrets.GITHUB_TOKEN || github.token }}
+      GITHUB_TOKEN_INPUT: ${{ github.token }}
       PAT_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
     
     steps:

--- a/.github/workflows/ai-dashboard.yml
+++ b/.github/workflows/ai-dashboard.yml
@@ -58,7 +58,7 @@ jobs:
       PR_NUMBER: ${{ inputs.pr_number || github.event.number || 'manual' }}
       REPO_NAME: ${{ inputs.repository_name || github.repository }}
       TARGET_BRANCH: ${{ inputs.target_branch || github.event.repository.default_branch || 'master' }}
-      GITHUB_TOKEN_INPUT: ${{ secrets.GITHUB_TOKEN || github.token }}
+      GITHUB_TOKEN_INPUT: ${{ github.token }}
       SHIFTAI_TOKEN_INPUT: ${{ secrets.SHIFTAI_TOKEN }}
     
     steps:


### PR DESCRIPTION
- Remove undefined secrets.GITHUB_TOKEN references
- Use github.token which is always available
- Add test file with AI code blocks for testing
- Ready for production use with 'secrets: inherit'