### PR TITLE
FIXED: Restore workflow_call with proper GITHUB_TOKEN handling

### DIFF
--- a/.github/workflows/ai-code-analysis.yml
+++ b/.github/workflows/ai-code-analysis.yml
@@ -1,8 +1,23 @@
 name: AI Code Analysis Report
 
 on:
-  # Temporarily disabled workflow_call for debugging
-  # workflow_call:
+  # Make this a reusable workflow
+  workflow_call:
+    inputs:
+      target_ref:
+        description: 'Target ref to analyze (default: PR head)'
+        required: false
+        type: string
+        default: ''
+      base_ref:
+        description: 'Base ref for comparison (default: PR base)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      PERSONAL_ACCESS_TOKEN:
+        description: 'Personal access token for user verification'
+        required: true
   
   # Still support direct usage on pull requests
   pull_request_target:
@@ -21,7 +36,7 @@ jobs:
       PR_USER_LOGIN: ${{ github.event.pull_request.user.login }}
       PR_HEAD_SHA: ${{ inputs.target_ref || github.event.pull_request.head.sha }}
       PR_BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
-      GITHUB_TOKEN_INPUT: ${{ secrets.GITHUB_TOKEN || github.token }}
+      GITHUB_TOKEN_INPUT: ${{ github.token }}
       PAT_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
     
     steps:


### PR DESCRIPTION
- Restore workflow_call section after debugging
- Only define PERSONAL_ACCESS_TOKEN in secrets
- Use github.token directly, no secrets.GITHUB_TOKEN reference
- Should fix Invalid secret GITHUB_TOKEN is not defined error