### PR TITLE
Add GITHUB_TOKEN as optional secret for inherit compatibility

### DIFF
--- a/.github/workflows/ai-code-analysis.yml
+++ b/.github/workflows/ai-code-analysis.yml
@@ -18,6 +18,9 @@ on:
       PERSONAL_ACCESS_TOKEN:
         description: 'Personal access token for user verification'
         required: true
+      GITHUB_TOKEN:
+        description: 'GitHub token (inherited automatically)'
+        required: false
   
   # Still support direct usage on pull requests
   pull_request_target:


### PR DESCRIPTION
- Define GITHUB_TOKEN as optional secret to support secrets: inherit
- Required when caller uses secrets: inherit with GITHUB_TOKEN
- Should fix persistent Invalid secret GITHUB_TOKEN not defined error