### PR TITLE
Prince/Add shiftai workflows

### DIFF
--- a/.github/workflows/ai-code-analysis.yml
+++ b/.github/workflows/ai-code-analysis.yml
@@ -18,9 +18,6 @@ on:
       PERSONAL_ACCESS_TOKEN:
         description: 'Personal access token for user verification'
         required: true
-      GITHUB_TOKEN:
-        description: 'GitHub token (inherited automatically)'
-        required: false
   
   # Still support direct usage on pull requests
   pull_request_target:


### PR DESCRIPTION
…llision

- Remove GITHUB_TOKEN from workflow_call secrets (GitHub reserved name)
- Keep only PERSONAL_ACCESS_TOKEN as required secret
- Use github.token directly in workflow (always available)
- Breaks the catch-22 loop - ready for production