### PR TITLE
Fix: Include time in dashboard timestamp to ensure updates

### DIFF
--- a/.github/workflows/ai-dashboard.yml
+++ b/.github/workflows/ai-dashboard.yml
@@ -279,7 +279,7 @@ jobs:
           const fs = require('fs');
 
           function generateMarkdown(stats, analyses, repo) {
-            const lastUpdate = new Date().toISOString().split('T')[0];
+            const lastUpdate = new Date().toISOString().replace('T', ' ').substring(0, 19) + ' UTC';
             
             function createStatsProgressBar(percentage) {
               const width = 10;


### PR DESCRIPTION
- Changed from date-only (2024-08-01) to date+time (2024-08-01 14:30:15 UTC)
- Ensures AI-DASHBOARD.md always has unique content on each run
- Prevents multiple runs on same day from generating identical content
- Now both history.json AND dashboard.md will be committed every time